### PR TITLE
Fix: Add 'status' field so it matches specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and rejection.
 Promise.allSettled(promises)
 .then((results) => {
     results.forEach(function (result) {
-        if (result.state === "fulfilled") {
+        if (result.status === "fulfilled") {
           let value = result.value;
         } else {
           let reason = result.reason;

--- a/dist/es2015-Promise.allSettled.js
+++ b/dist/es2015-Promise.allSettled.js
@@ -2,7 +2,7 @@ if (Promise && !Promise.allSettled) {
   Promise.allSettled = (promises) =>
     Promise.all(promises.map((promise) =>
       promise
-        .then((value) => ({state: 'fulfilled', value}))
-        .catch((reason) => ({state: 'rejected', reason}))
+        .then((value) => ({status: 'fulfilled', state: 'fulfilled', value}))
+        .catch((reason) => ({status: 'rejected', state: 'rejected', reason}))
     ))
 }

--- a/dist/es2015.Promise.allSettled.ponyfill.js
+++ b/dist/es2015.Promise.allSettled.ponyfill.js
@@ -5,9 +5,9 @@ if (Promise && !Promise.allSettled) {
   Promise.allSettled = function (promises) {
     return Promise.all(promises.map(function (promise) {
       return promise.then(function (value) {
-        return { state: 'fulfilled', value: value };
+        return { status: 'fulfilled', state: 'fulfilled', value: value };
       }).catch(function (reason) {
-        return { state: 'rejected', reason: reason };
+        return { status: 'rejected', state: 'rejected', reason: reason };
       });
     }));
   };

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ if (Promise && !Promise.allSettled) {
   Promise.allSettled = function (promises) {
     return Promise.all(promises.map(function (promise) {
       return promise.then(function (value) {
-        return { state: 'fulfilled', value: value };
+        return { status: 'fulfilled', state: 'fulfilled', value: value };
       }).catch(function (reason) {
-        return { state: 'rejected', reason: reason };
+        return { status: 'rejected', state: 'rejected', reason: reason };
       });
     }));
   };

--- a/src/promise-allsettled-ponyfill.js
+++ b/src/promise-allsettled-ponyfill.js
@@ -2,7 +2,7 @@ if (Promise && !Promise.allSettled) {
   Promise.allSettled = (promises) =>
     Promise.all(promises.map((promise) =>
       promise
-        .then((value) => ({state: 'fulfilled', value}))
-        .catch((reason) => ({state: 'rejected', reason}))
+        .then((value) => ({status: 'fulfilled', state: 'fulfilled', value}))
+        .catch((reason) => ({status: 'rejected', state: 'rejected', reason}))
     ))
 }

--- a/test/promise-allsettled.test.js
+++ b/test/promise-allsettled.test.js
@@ -16,8 +16,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.resolve('yeah2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('fulfilled');
       expect(results[0].state).to.be.equal('fulfilled');
       expect(results[0].value).to.be.equal('yeah1');
+      expect(results[1].status).to.be.equal('fulfilled');
       expect(results[1].state).to.be.equal('fulfilled');
       expect(results[1].value).to.be.equal('yeah2');
     })
@@ -29,8 +31,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.reject('boo');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('fulfilled');
       expect(results[0].state).to.be.equal('fulfilled');
       expect(results[0].value).to.be.equal('yeah1');
+      expect(results[1].status).to.be.equal('rejected');
       expect(results[1].state).to.be.equal('rejected');
       expect(results[1].reason).to.be.equal('boo');
     })
@@ -41,8 +45,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.resolve('yeah2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('rejected');
       expect(results[0].state).to.be.equal('rejected');
       expect(results[0].reason).to.be.equal('boo1');
+      expect(results[1].status).to.be.equal('fulfilled');
       expect(results[1].state).to.be.equal('fulfilled');
       expect(results[1].value).to.be.equal('yeah2');
     })
@@ -53,8 +59,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.reject('boo2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('rejected');
       expect(results[0].state).to.be.equal('rejected');
       expect(results[0].reason).to.be.equal('boo1');
+      expect(results[1].status).to.be.equal('rejected');
       expect(results[1].state).to.be.equal('rejected');
       expect(results[1].reason).to.be.equal('boo2');
     })
@@ -72,6 +80,7 @@ describe('Promise.allSettled', function(){
       expect(results).to.be.an('array');
       expect(results).to.have.length(10000);
       results.forEach((result) => {
+        expect(result.status).to.be.equal('fulfilled');
         expect(result.state).to.be.equal('fulfilled');
         expect(result.value).to.be.equal('yeah1')
       });

--- a/tests/promise-allsettled.test.js
+++ b/tests/promise-allsettled.test.js
@@ -10,8 +10,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.resolve('yeah2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('fulfilled');
       expect(results[0].state).to.be.equal('fulfilled');
       expect(results[0].value).to.be.equal('yeah1');
+      expect(results[1].status).to.be.equal('fulfilled');
       expect(results[1].state).to.be.equal('fulfilled');
       expect(results[1].value).to.be.equal('yeah2');
     })
@@ -23,8 +25,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.reject('boo');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('fulfilled');
       expect(results[0].state).to.be.equal('fulfilled');
       expect(results[0].value).to.be.equal('yeah1');
+      expect(results[1].status).to.be.equal('rejected');
       expect(results[1].state).to.be.equal('rejected');
       expect(results[1].reason).to.be.equal('boo');
     })
@@ -35,8 +39,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.resolve('yeah2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('rejected');
       expect(results[0].state).to.be.equal('rejected');
       expect(results[0].reason).to.be.equal('boo1');
+      expect(results[1].status).to.be.equal('fulfilled');
       expect(results[1].state).to.be.equal('fulfilled');
       expect(results[1].value).to.be.equal('yeah2');
     })
@@ -47,8 +53,10 @@ describe('Promise.allSettled', function(){
     const promise2 = Promise.reject('boo2');
     return Promise.allSettled([promise1, promise2]).then((results) => {
       expect(results).to.be.an('array');
+      expect(results[0].status).to.be.equal('rejected');
       expect(results[0].state).to.be.equal('rejected');
       expect(results[0].reason).to.be.equal('boo1');
+      expect(results[1].status).to.be.equal('rejected');
       expect(results[1].state).to.be.equal('rejected');
       expect(results[1].reason).to.be.equal('boo2');
     })
@@ -66,6 +74,7 @@ describe('Promise.allSettled', function(){
       expect(results).to.be.an('array');
       expect(results).to.have.length(10000);
       results.forEach((result) => {
+        expect(result.status).to.be.equal('fulfilled');
         expect(result.state).to.be.equal('fulfilled');
         expect(result.value).to.be.equal('yeah1')
       });


### PR DESCRIPTION
This fix simply adds the missing required `status` field, per the [technical specification](https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled-reject-element-functions).  See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled


Ideally this would also be missing the state field. However, I left the original `state` field intact to ensure backward compatibility since this isn't intended to be a full version upgrade (per [semver](https://semver.org/)). But for reference, this is **what it should** look like if it matched spec (just for reference since I'll be using it in my code 😄):

```js
if (Promise && !Promise.allSettled) {
  Promise.allSettled = function (promises) {
    return Promise.all(promises.map(function (promise) {
      return promise.then(function (value) {
        return { status: 'fulfilled', value: value };
      }).catch(function (reason) {
        return { status: 'rejected', reason: reason };
      });
    }));
  };
}
```

**NOTE:** I wasn't able to install `gulp` due to the fact that they've deleted the `4.0` branch and this PR isn't intended to address that per se. As a result, I was unable to run tests. 

